### PR TITLE
Improve Circuit Breaker Options for IoC Wiring

### DIFF
--- a/Pat.Subscriber.NetCoreDependencyResolution/IPatLiteOptionsBuilder.cs
+++ b/Pat.Subscriber.NetCoreDependencyResolution/IPatLiteOptionsBuilder.cs
@@ -10,8 +10,8 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
         IBatchPipelineBuilder DefineBatchPipeline { get; }
         IPatLiteOptionsBuilder WithMessageDeserialiser(Func<IServiceProvider, IMessageDeserialiser> func);
 
-        IPatLiteOptionsBuilder UseDefaultPipelinesWithCircuitBreaker(
-            CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions circuitBreakerOptions);
+        IPatLiteOptionsBuilder UseDefaultPipelinesWithCircuitBreaker(Func<IServiceProvider, 
+            CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions> func);
         PatLiteOptions Build();
     }
 }

--- a/Pat.Subscriber.NetCoreDependencyResolution/PatLiteDependencyHelper.cs
+++ b/Pat.Subscriber.NetCoreDependencyResolution/PatLiteDependencyHelper.cs
@@ -76,7 +76,7 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
             BatchPipelineDependencyBuilder batchMessageProcessingBehaviourBuilder, 
             MessagePipelineDependencyBuilder messagePipelineDependencyBuilder,
             Func<IServiceProvider, IMessageDeserialiser> messageDeserialiser,
-            CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions circuitBreakerOptions)
+            Func<IServiceProvider, CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions> circuitBreakerOptions)
         {
             messagePipelineDependencyBuilder?.RegisterTypes(serviceCollection);
             batchMessageProcessingBehaviourBuilder?.RegisterTypes(serviceCollection);

--- a/Pat.Subscriber.NetCoreDependencyResolution/PatLiteOptions.cs
+++ b/Pat.Subscriber.NetCoreDependencyResolution/PatLiteOptions.cs
@@ -36,8 +36,8 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
 
         /// <summary>
         /// Optional
-        /// If a circuit breaker is used these are the options applied.
+        /// by default no exceptions cause circuit breaking.
         /// </summary>
-        public CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions CircuitBreakerOptions { get; set; }
+        public Func<IServiceProvider, CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions> CircuitBreakerOptions { get; set; }
     }
 }

--- a/Pat.Subscriber.NetCoreDependencyResolution/PatLiteOptionsBuilder.cs
+++ b/Pat.Subscriber.NetCoreDependencyResolution/PatLiteOptionsBuilder.cs
@@ -14,7 +14,7 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
         private readonly ICollection<Type> _messagePipelineBehaviourTypes = new List<Type>();
         private readonly ICollection<Type> _batchPipelineBehaviourTypes = new List<Type>();
         private Func<IServiceProvider, IMessageDeserialiser> _messageDeserialiser = provider => new NewtonsoftMessageDeserialiser();
-        private CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions _circuitBreakerOptions;
+        private Func<IServiceProvider, CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions> _circuitBreakerOptions = provider => new CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions(1, e => false);
 
         public PatLiteOptionsBuilder(SubscriberConfiguration subscriberConfiguration)
         {
@@ -82,7 +82,7 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
             return instance.Build();
         }
 
-        public IPatLiteOptionsBuilder UseDefaultPipelinesWithCircuitBreaker(CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions circuitBreakerOptions)
+        public IPatLiteOptionsBuilder UseDefaultPipelinesWithCircuitBreaker(Func<IServiceProvider, CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions> func)
         {
             _messagePipelineBehaviourTypes.Clear();
             _messagePipelineBehaviourTypes.Add(typeof(DefaultMessageProcessingBehaviour));
@@ -93,7 +93,7 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
             _batchPipelineBehaviourTypes.Add(typeof(CircuitBreakerBatchProcessingBehaviour));
             _batchPipelineBehaviourTypes.Add(typeof(MonitoringBatchProcessingBehaviour));
             _batchPipelineBehaviourTypes.Add(typeof(DefaultBatchProcessingBehaviour));
-            _circuitBreakerOptions = circuitBreakerOptions;
+            _circuitBreakerOptions = func;
             return this;
         }
     }

--- a/Pat.Subscriber.UnitTests/Behaviours/CircuitBreakerTests.cs
+++ b/Pat.Subscriber.UnitTests/Behaviours/CircuitBreakerTests.cs
@@ -61,11 +61,13 @@ namespace Pat.Subscriber.UnitTests.Behaviours
             };
             _events = Substitute.For<ICircuitBreakerEvents>();
 
+            var circuitBreakerOptions = new CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions(1, exception => false);
+            circuitBreakerOptions.CircuitBroken += _events.Broken;
+            circuitBreakerOptions.CircuitReset += _events.Reset;
+            circuitBreakerOptions.CircuitTest += _events.TestCircuit;
+
             _circuitBreakerBatchProcessingBehaviour = new CircuitBreakerBatchProcessingBehaviour(Substitute.For<ILog>(),
-                config, new CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions(1, exception => false));
-            _circuitBreakerBatchProcessingBehaviour.CircuitBroken += _events.Broken;
-            _circuitBreakerBatchProcessingBehaviour.CircuitReset += _events.Reset;
-            _circuitBreakerBatchProcessingBehaviour.CircuitTest += _events.TestCircuit;
+                config, circuitBreakerOptions);
 
             _batchProcessingBehaviourPipeline = new BatchProcessingBehaviourPipeline()
                 .AddBehaviour(_circuitBreakerBatchProcessingBehaviour)

--- a/Pat.Subscriber/CicuitBreaker/CircuitBreakerBatchProcessingBehaviour.cs
+++ b/Pat.Subscriber/CicuitBreaker/CircuitBreakerBatchProcessingBehaviour.cs
@@ -17,6 +17,9 @@ namespace Pat.Subscriber.CicuitBreaker
 
             public int CircuitTestIntervalInSeconds { get; }
             public Func<Exception, bool> ShouldCircuitBreak { get; }
+            public CircuitBrokenHandler CircuitBroken;
+            public CircuitResetHandler CircuitReset;
+            public CircuitTestHandler CircuitTest;
         }
 
         public delegate void CircuitBrokenHandler(object sender, EventArgs e);
@@ -34,9 +37,9 @@ namespace Pat.Subscriber.CicuitBreaker
         private readonly SubscriberConfiguration _config;
         private readonly int _circuitTestIntervalInSeconds;
         public Func<Exception, bool> ShouldCircuitBreak { get; set; }
-        public event CircuitBrokenHandler CircuitBroken;
-        public event CircuitResetHandler CircuitReset;
-        public event CircuitResetHandler CircuitTest;
+        private event CircuitBrokenHandler CircuitBroken;
+        private event CircuitResetHandler CircuitReset;
+        private event CircuitTestHandler CircuitTest;
 
         public CircuitBreakerBatchProcessingBehaviour(ILog log, SubscriberConfiguration config, CircuitBreakerOptions circuitBreakerOptions)
         {
@@ -45,6 +48,9 @@ namespace Pat.Subscriber.CicuitBreaker
             ShouldCircuitBreak = circuitBreakerOptions.ShouldCircuitBreak;
             _circuitTestIntervalInSeconds = circuitBreakerOptions.CircuitTestIntervalInSeconds;
             State = CircuitState.Closed;
+            CircuitBroken += circuitBreakerOptions.CircuitBroken;
+            CircuitReset += circuitBreakerOptions.CircuitReset;
+            CircuitTest += circuitBreakerOptions.CircuitTest;
         }
 
         private void OnCircuitBroken(EventArgs e)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 1.1.{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:


### PR DESCRIPTION
This is done so that clients using IoC are able to hook complex services
into the events.