### PR TITLE
Decouple DefaultMessageProcessingBehaviour from InvokeHandlerBehaviour

### DIFF
--- a/Pat.Subscriber.UnitTests/Behaviours/InvokeHandlerBehaviour.cs
+++ b/Pat.Subscriber.UnitTests/Behaviours/InvokeHandlerBehaviour.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Threading.Tasks;
+using log4net;
 using Microsoft.Azure.ServiceBus;
 using Newtonsoft.Json;
 using NSubstitute;
@@ -26,18 +27,20 @@ namespace Pat.Subscriber.UnitTests.Behaviours
         {
         }
 
+        private readonly ILog _log = Substitute.For<ILog>();
+        private readonly SubscriberConfiguration _config = Substitute.For<SubscriberConfiguration>();
 
         [Fact]
-        public async Task  When_InvokedHandlerThrowsException_ThenBehaviourThrowsUnwrappedException()
+        public async Task When_InvokedHandlerThrowsException_ThenBehaviourThrowsUnwrappedException()
         {
-            var invokeHandlerBehaviour = Substitute.ForPartsOf<InvokeHandlerBehaviour>();
+            var invokeHandlerBehaviour = Substitute.ForPartsOf<InvokeHandlerBehaviour>(_log, _config);
             invokeHandlerBehaviour.GetHandlerForMessageType(Arg.Any<Message>())
                 .ReturnsForAnyArgs(new MessageTypeMapping(typeof(TestEvent), typeof(FakeHandler)));
 
             var messageDependencyScope = Substitute.For<IMessageDependencyScope>();
             messageDependencyScope.GetService(null).ReturnsForAnyArgs(new FakeHandler());
             messageDependencyScope.GetService<IMessageDeserialiser>().Returns(new NewtonsoftMessageDeserialiser());
-           var messageContext = new MessageContext
+            var messageContext = new MessageContext
             {
                 Message = new Message(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new TestEvent()))),
                 DependencyScope = messageDependencyScope

--- a/Pat.Subscriber/MessageProcessing/DefaultMessageProcessingBehaviour.cs
+++ b/Pat.Subscriber/MessageProcessing/DefaultMessageProcessingBehaviour.cs
@@ -30,24 +30,10 @@ namespace Pat.Subscriber.MessageProcessing
                 await messageContext.MessageReceiver.CompleteAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
                 _log.Debug($"{_config.SubscriberName} Success Handling Message {message.MessageId} correlation id `{GetCollelationId(message)}`: {message.ContentType}");
             }
-            catch (SerializationException ex)
-            {
-                var messageType = GetMessageType(message);
-                var correlationId = GetCollelationId(message);
-                await messageContext.MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
-                _log.Warn($"Unable to deserialise message body, message deadlettered. `{messageType}` correlation id `{correlationId}` on subscriber `{_config.SubscriberName}`.", ex);
-            }
             catch (Exception ex)
             {
                 _log.Info($"Message {message.MessageId} failed", ex);
             }
-        }
-
-        private static string GetMessageType(Message message)
-        {
-            return message.UserProperties.ContainsKey("MessageType")
-                ? message.UserProperties["MessageType"].ToString()
-                : "Unknown Message Type";
         }
 
         private static string GetCollelationId(Message message)


### PR DESCRIPTION
The responsibility of handling the `SerializationException` in the `DefaultMessageProcessingBehaviour`
is only there because the `InvokeHandlerBehaviour` might throw the exception as part of its
activities.

On that bassis, the InvokeHandlerBehaviour should own that exception handling responsibility, rather
than something higher up the pipeline