### PR TITLE
Replace net451/log4net with .NET Standard/Core logging

### DIFF
--- a/Pat.Subscriber.DataProtectionDecryption.NetCoreDependencyResolution/Pat.Subscriber.DataProtectionDecryption.NetCoreDependencyResolution.csproj
+++ b/Pat.Subscriber.DataProtectionDecryption.NetCoreDependencyResolution/Pat.Subscriber.DataProtectionDecryption.NetCoreDependencyResolution.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
     <Version>1.0.0</Version>
     <Summary>Purplebricks message subscriber infrastructure: Decryption with .Net Core DI support</Summary>
@@ -18,11 +18,7 @@
     <ProjectReference Include="..\Pat.Subscriber.DataProtectionDecryption\Pat.Subscriber.DataProtectionDecryption.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'NET451'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 

--- a/Pat.Subscriber.DataProtectionDecryption.StructureMap4DependencyResolution/Pat.Subscriber.DataProtectionDecryption.StructureMap4DependencyResolution.csproj
+++ b/Pat.Subscriber.DataProtectionDecryption.StructureMap4DependencyResolution/Pat.Subscriber.DataProtectionDecryption.StructureMap4DependencyResolution.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
     <Version>1.0.0</Version>
     <Summary>Purplebricks message subscriber infrastructure: Decryption with StructureMap support</Summary>

--- a/Pat.Subscriber.DataProtectionDecryption/Pat.Subscriber.DataProtectionDecryption.csproj
+++ b/Pat.Subscriber.DataProtectionDecryption/Pat.Subscriber.DataProtectionDecryption.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
     <Version>1.0.0</Version>
     <Summary>Purplebricks message subscriber infrastructure: Decryption</Summary>

--- a/Pat.Subscriber.IntegrationTests/DependencyResolution/DotNetIoCExtensions.cs
+++ b/Pat.Subscriber.IntegrationTests/DependencyResolution/DotNetIoCExtensions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using log4net;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Pat.Sender;
 using Pat.Subscriber.IntegrationTests.Helpers;
@@ -28,7 +28,7 @@ namespace Pat.Subscriber.IntegrationTests.DependencyResolution
             serviceCollection
                 .AddSingleton(messageReceiver)
                 .AddSingleton<MessageReceiverFactory>(provider => new FakeMessageReceiverFactory(
-                    provider.GetService<ILog>(),
+                    provider.GetService<ILogger>(),
                     provider.GetService<SubscriberConfiguration>(),
                     provider.GetService<IMessageReceiver>()))
                 .AddSingleton(provider => new MessageWaiter<TestEvent>(

--- a/Pat.Subscriber.IntegrationTests/DependencyResolution/StructureMapExtensions.cs
+++ b/Pat.Subscriber.IntegrationTests/DependencyResolution/StructureMapExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using log4net;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Pat.Sender;
 using Pat.Subscriber.IntegrationTests.Helpers;
@@ -24,7 +24,7 @@ namespace Pat.Subscriber.IntegrationTests.DependencyResolution
             container.Configure(x =>
             {
                 x.For<MessageReceiverFactory>().Use(context => new FakeMessageReceiverFactory(
-                    context.GetInstance<ILog>(),
+                    context.GetInstance<ILogger>(),
                     context.GetInstance<SubscriberConfiguration>(),
                     messageReceiver));
                 x.For<MessageWaiter<TestEvent>>().Use(context => new MessageWaiter<TestEvent>(

--- a/Pat.Subscriber.IntegrationTests/DependencyResolution/StructureMapIoC.cs
+++ b/Pat.Subscriber.IntegrationTests/DependencyResolution/StructureMapIoC.cs
@@ -37,7 +37,8 @@ namespace Pat.Subscriber.IntegrationTests.DependencyResolution
             {
                 x.AddRegistry(new PatLiteRegistry(new PatLiteOptions
                 {
-                    SubscriberConfiguration = subscriberConfiguration
+                    SubscriberConfiguration = subscriberConfiguration,
+                    RegisterDefaultLoggerWithName = "Pat"
                 }));
             });
 

--- a/Pat.Subscriber.IntegrationTests/DotNetIoCSubscriberTests.cs
+++ b/Pat.Subscriber.IntegrationTests/DotNetIoCSubscriberTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using log4net;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Pat.Subscriber.BatchProcessing;
 using Pat.Subscriber.IntegrationTests.DependencyResolution;
@@ -51,15 +52,13 @@ namespace Pat.Subscriber.IntegrationTests
             _configuration.GetSection("StatsD").Bind(statisticsConfiguration);
             _statisticsReporter = Substitute.For<IStatisticsReporter>();
 
-            var loggerName = "IntegrationLogger-DotNetIoC";
-            Logging.InitLogger(loggerName);
-
             var serviceProvider = serviceCollection
                 .AddSingleton(statisticsConfiguration)
                 .AddSingleton<MessageReceivedNotifier<TestEvent>>()
-                .AddSingleton(LogManager.GetLogger(loggerName, loggerName))
                 .AddSingleton(_statisticsReporter)
                 .AddHandlersFromAssemblyContainingType<DotNetIoC>()
+                .AddDefaultPatLogger()
+                .AddLogging(b => b.AddDebug())
                 .BuildServiceProvider();
 
             return serviceProvider;

--- a/Pat.Subscriber.IntegrationTests/Helpers/FakeMessageReceiverFactory.cs
+++ b/Pat.Subscriber.IntegrationTests/Helpers/FakeMessageReceiverFactory.cs
@@ -1,5 +1,6 @@
 ﻿using log4net;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Pat.Subscriber.IntegrationTests.Helpers
 {
@@ -7,7 +8,7 @@ namespace Pat.Subscriber.IntegrationTests.Helpers
     {
         private readonly IMessageReceiver _messageReceiver;
 
-        public FakeMessageReceiverFactory(ILog log, SubscriberConfiguration config, IMessageReceiver fakeMessageReceiver) : base(log, config)
+        public FakeMessageReceiverFactory(ILogger log, SubscriberConfiguration config, IMessageReceiver fakeMessageReceiver) : base(log, config)
         {
             _messageReceiver = fakeMessageReceiver;
         }

--- a/Pat.Subscriber.IntegrationTests/Pat.Subscriber.IntegrationTests.csproj
+++ b/Pat.Subscriber.IntegrationTests/Pat.Subscriber.IntegrationTests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Pat.Sender.DataProtectionEncryption" Version="2.0.3" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Pat.Subscriber.IntegrationTests/StructureMapSubscriberTests.cs
+++ b/Pat.Subscriber.IntegrationTests/StructureMapSubscriberTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using log4net;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Pat.Subscriber.BatchProcessing;
 using Pat.Subscriber.IntegrationTests.DependencyResolution;
@@ -82,7 +83,10 @@ namespace Pat.Subscriber.IntegrationTests
         {
             var container = SetupContainer(x =>
             {
-                x.AddRegistry(new PatLiteRegistryBuilder(_subscriberConfiguration).Build());
+                x.AddRegistry(new PatLiteRegistryBuilder(_subscriberConfiguration)
+                    .WithDefaultPatLogger()
+                    .Build());
+                x.ForSingletonOf<ILoggerFactory>().Use(s => new LoggerFactory());
             });
             container.SetupTestMessage(_correlationId);
 
@@ -101,7 +105,10 @@ namespace Pat.Subscriber.IntegrationTests
         {
             var container = SetupContainer(x =>
             {
-                x.AddRegistry(new PatLiteRegistryBuilder(_subscriberConfiguration).Build());
+                x.AddRegistry(new PatLiteRegistryBuilder(_subscriberConfiguration)
+                    .WithDefaultPatLogger()
+                    .Build());
+                x.ForSingletonOf<ILoggerFactory>().Use(s => new LoggerFactory());
             });
             container.SetupTestMessage(_correlationId);
 
@@ -127,11 +134,13 @@ namespace Pat.Subscriber.IntegrationTests
             var container = SetupContainer(x =>
             {
                 x.AddRegistry(new PatLiteRegistryBuilder(_subscriberConfiguration)
+                    .WithDefaultPatLogger()
                     .DefineMessagePipeline
                         .With<DefaultMessageProcessingBehaviour>()
                         .With<MockMessageProcessingBehaviour>()
                         .With<InvokeHandlerBehaviour>()
                     .Build());
+                x.ForSingletonOf<ILoggerFactory>().Use(s => new LoggerFactory());
             });
             container.SetupTestMessage(_correlationId);
 
@@ -153,10 +162,12 @@ namespace Pat.Subscriber.IntegrationTests
             var container = SetupContainer(x =>
             {
                 x.AddRegistry(new PatLiteRegistryBuilder(_subscriberConfiguration)
+                    .WithDefaultPatLogger()
                     .DefineBatchPipeline
                         .With<MockBatchProcessingBehaviour>()
                         .With<DefaultBatchProcessingBehaviour>()
                     .Build());
+                x.ForSingletonOf<ILoggerFactory>().Use(s => new LoggerFactory());
             });
             container.Configure(x => x.For<MockBatchProcessingBehaviour>()
                 .Use(context => new MockBatchProcessingBehaviour(_correlationId)));

--- a/Pat.Subscriber.NetCoreDependencyResolution/Pat.Subscriber.NetCoreDependencyResolution.csproj
+++ b/Pat.Subscriber.NetCoreDependencyResolution/Pat.Subscriber.NetCoreDependencyResolution.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
-    <Version>2.0.0</Version>
+    <Version>0.0.0</Version>
     <Summary>Purplebricks message subscriber infrastructure: .Net Core dependency resolution helper</Summary>
     <Description>Purplebricks message subscriber infrastructure: .Net Core dependency resolution helper</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -15,10 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\net462\PB.ITOps.Messaging.PatLite.Net.Core.DependencyResolution.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NET451'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NETSTANDARD2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Pat.Subscriber.NetCoreDependencyResolution/PatLiteDependencyHelper.cs
+++ b/Pat.Subscriber.NetCoreDependencyResolution/PatLiteDependencyHelper.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using log4net;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber.BatchProcessing;
 using Pat.Subscriber.CicuitBreaker;
 using Pat.Subscriber.Deserialiser;
@@ -71,6 +71,11 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
             return serviceCollection.RegisterPatLite(null, null, null, null);
         }
 
+        public static IServiceCollection AddDefaultPatLogger(this IServiceCollection serviceCollection)
+        {
+            return serviceCollection.AddSingleton(s => s.GetRequiredService<ILoggerFactory>().CreateLogger("Pat"));
+        }
+
         private static IServiceCollection RegisterPatLite(
             this IServiceCollection serviceCollection,
             BatchPipelineDependencyBuilder batchMessageProcessingBehaviourBuilder, 
@@ -98,7 +103,7 @@ namespace Pat.Subscriber.NetCoreDependencyResolution
                 .AddSingleton(provider => 
                     new MultipleBatchProcessor(
                         provider.GetService<BatchProcessor>(),
-                        provider.GetService<ILog>(),
+                        provider.GetService<ILogger>(),
                         provider.GetService<SubscriberConfiguration>().SubscriberName))
                 .AddSingleton<MessageReceiverFactory, AzureServiceBusMessageReceiverFactory>()
                 .AddSingleton<BatchFactory>()

--- a/Pat.Subscriber.RateLimiterPolicy/Pat.Subscriber.RateLimiterPolicy.csproj
+++ b/Pat.Subscriber.RateLimiterPolicy/Pat.Subscriber.RateLimiterPolicy.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
-    <Version>1.0.0</Version>
+    <Version>1.0.4-preview</Version>
     <Summary>Purplebricks message subscriber infrastructure: RateLimiterPolicy</Summary>
     <Description>Purplebricks message subscriber infrastructure: RateLimiterPolicy</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,14 +11,12 @@
     <PackageLicenseUrl>https://github.com/purplebricks/Pat.Subscriber/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/purplebricks/Pat.Subscriber</RepositoryUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nito.Collections.Deque" Version="1.0.4" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NET451'">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NETSTANDARD2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Pat.Subscriber.StructureMap4DependencyResolution/Pat.Subscriber.StructureMap4DependencyResolution.csproj
+++ b/Pat.Subscriber.StructureMap4DependencyResolution/Pat.Subscriber.StructureMap4DependencyResolution.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
-    <Version>1.0.0</Version>
+    <Version>1.0.4-preview</Version>
     <Summary>Purplebricks message subscriber infrastructure: StructureMap resolution helper</Summary>
     <Description>Purplebricks message subscriber infrastructure: StructureMap dependency resolution helper</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,9 +11,9 @@
     <PackageLicenseUrl>https://github.com/purplebricks/Pat.Subscriber/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/purplebricks/Pat.Subscriber</RepositoryUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="StructureMap" Version="4.5.3" />
   </ItemGroup>
   <ItemGroup>

--- a/Pat.Subscriber.StructureMap4DependencyResolution/PatLiteOptions.cs
+++ b/Pat.Subscriber.StructureMap4DependencyResolution/PatLiteOptions.cs
@@ -10,5 +10,6 @@ namespace Pat.Subscriber.StructureMap4DependencyResolution
         public BatchPipelineDependencyBuilder BatchMessageProcessingBehaviourDependencyBuilder { get; set; }
         public MessagePipelineDependencyBuilder MessageProcessingPipelineDependencyBuilder { get; set; }
         public Func<IContext, IMessageDeserialiser> MessageDeserialiser { get; set; }
+        public string RegisterDefaultLoggerWithName { get; set; }
     }
 }

--- a/Pat.Subscriber.StructureMap4DependencyResolution/PatLiteRegistry.cs
+++ b/Pat.Subscriber.StructureMap4DependencyResolution/PatLiteRegistry.cs
@@ -1,4 +1,4 @@
-﻿using log4net;
+﻿using Microsoft.Extensions.Logging;
 using Pat.Subscriber.BatchProcessing;
 using Pat.Subscriber.Deserialiser;
 using Pat.Subscriber.IoC;
@@ -19,13 +19,17 @@ namespace Pat.Subscriber.StructureMap4DependencyResolution
             });
 
             For<IMessageDependencyResolver>().Use<StructureMapDependencyResolver>();
-            For<ILog>().AlwaysUnique().Use(s => LogManager.GetLogger(s.RootType));
         }
 
         public PatLiteRegistry(PatLiteOptions options): this(options.BatchMessageProcessingBehaviourDependencyBuilder, options.MessageProcessingPipelineDependencyBuilder)
         {
             For<SubscriberConfiguration>().Use(options.SubscriberConfiguration);
             For<IMessageDeserialiser>().Use(context => options.MessageDeserialiser(context));
+
+            if (!string.IsNullOrEmpty(options.RegisterDefaultLoggerWithName))
+            {
+                For<ILogger>().Use(context => context.GetInstance<ILoggerFactory>().CreateLogger(options.RegisterDefaultLoggerWithName));
+            }
         }
 
         private PatLiteRegistry(BatchPipelineDependencyBuilder batchMessageProcessingBehaviourPipelineDependencyBuilder,

--- a/Pat.Subscriber.StructureMap4DependencyResolution/PatLiteRegistryBuilder.cs
+++ b/Pat.Subscriber.StructureMap4DependencyResolution/PatLiteRegistryBuilder.cs
@@ -14,6 +14,7 @@ namespace Pat.Subscriber.StructureMap4DependencyResolution
         private readonly ICollection<Type> _batchPipelineBehaviourTypes = new List<Type>();
         private readonly SubscriberConfiguration _subscriberConfiguration;
         private Func<IContext, IMessageDeserialiser> _messageDeserialiser = provider => new NewtonsoftMessageDeserialiser();
+        private string _registerDefaultLoggerWithName;
 
         public PatLiteRegistryBuilder(SubscriberConfiguration subscriberConfiguration)
         {
@@ -61,6 +62,12 @@ namespace Pat.Subscriber.StructureMap4DependencyResolution
             return this;
         }
 
+        public IPatLiteRegistryBuilder WithDefaultPatLogger(string categoryName = "Pat")
+        {
+            _registerDefaultLoggerWithName = categoryName;
+            return this;
+        }
+
         public PatLiteRegistry Build()
         {
             var builder = new MessagePipelineDependencyBuilder(_messagePipelineBehaviourTypes);
@@ -70,7 +77,8 @@ namespace Pat.Subscriber.StructureMap4DependencyResolution
                 SubscriberConfiguration = _subscriberConfiguration,
                 MessageProcessingPipelineDependencyBuilder = builder,
                 BatchMessageProcessingBehaviourDependencyBuilder = batchBuilder,
-                MessageDeserialiser = _messageDeserialiser
+                MessageDeserialiser = _messageDeserialiser,
+                RegisterDefaultLoggerWithName = _registerDefaultLoggerWithName
             };
             return new PatLiteRegistry(patliteOptions);
         }

--- a/Pat.Subscriber.Telemetry.StatsD/Pat.Subscriber.Telemetry.StatsD.csproj
+++ b/Pat.Subscriber.Telemetry.StatsD/Pat.Subscriber.Telemetry.StatsD.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
-    <Version>1.0.0</Version>
+    <Version>0.0.0</Version>
     <Summary>Purplebricks message subscriber infrastructure: StatsD Monitoring Behaviour</Summary>
     <Description>Purplebricks message subscriber infrastructure: StatsD Monitoring Behaviour</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -15,10 +15,7 @@
   <ItemGroup>
     <PackageReference Include="StatsdClient" Version="3.0.86" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NET451'">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NETSTANDARD2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Pat.Subscriber.UnitTests/Behaviours/CircuitBreakerTests.cs
+++ b/Pat.Subscriber.UnitTests/Behaviours/CircuitBreakerTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using log4net;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Pat.Subscriber.BatchProcessing;
 using Pat.Subscriber.CicuitBreaker;
@@ -66,18 +66,18 @@ namespace Pat.Subscriber.UnitTests.Behaviours
             circuitBreakerOptions.CircuitReset += _events.Reset;
             circuitBreakerOptions.CircuitTest += _events.TestCircuit;
 
-            _circuitBreakerBatchProcessingBehaviour = new CircuitBreakerBatchProcessingBehaviour(Substitute.For<ILog>(),
+            _circuitBreakerBatchProcessingBehaviour = new CircuitBreakerBatchProcessingBehaviour(Substitute.For<ILogger>(),
                 config, circuitBreakerOptions);
 
             _batchProcessingBehaviourPipeline = new BatchProcessingBehaviourPipeline()
                 .AddBehaviour(_circuitBreakerBatchProcessingBehaviour)
-                .AddBehaviour(new DefaultBatchProcessingBehaviour(Substitute.For<ILog>(), config));
+                .AddBehaviour(new DefaultBatchProcessingBehaviour(Substitute.For<ILogger>(), config));
 
             _mockHandleMessageBehaviour = new MockHandleMessageBehaviour();
             var circuitBreakerMessageProcessingBehaviour = new CircuitBreakerMessageProcessingBehaviour(_circuitBreakerBatchProcessingBehaviour);
             
             _messageProcessingPipeline = new MessageProcessingBehaviourPipeline()
-                .AddBehaviour(new DefaultMessageProcessingBehaviour(Substitute.For<ILog>(), config))
+                .AddBehaviour(new DefaultMessageProcessingBehaviour(Substitute.For<ILogger>(), config))
                 .AddBehaviour(circuitBreakerMessageProcessingBehaviour)
                 .AddBehaviour(_mockHandleMessageBehaviour);
 

--- a/Pat.Subscriber/AzureServiceBusMessageReceiverFactory.cs
+++ b/Pat.Subscriber/AzureServiceBusMessageReceiverFactory.cs
@@ -1,12 +1,12 @@
-using log4net;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Pat.Subscriber
 {
     public class AzureServiceBusMessageReceiverFactory : MessageReceiverFactory
     {
-        public AzureServiceBusMessageReceiverFactory(ILog log, SubscriberConfiguration config) : base(log, config)
+        public AzureServiceBusMessageReceiverFactory(ILogger log, SubscriberConfiguration config) : base(log, config)
         {
         }
 

--- a/Pat.Subscriber/BatchProcessing/DefaultBatchProcessingBehaviour.cs
+++ b/Pat.Subscriber/BatchProcessing/DefaultBatchProcessingBehaviour.cs
@@ -1,17 +1,17 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using log4net;
 using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
 
 namespace Pat.Subscriber.BatchProcessing
 {
     public class DefaultBatchProcessingBehaviour : IBatchProcessingBehaviour
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
         private readonly SubscriberConfiguration _config;
 
-        public DefaultBatchProcessingBehaviour(ILog log, SubscriberConfiguration config)
+        public DefaultBatchProcessingBehaviour(ILogger log, SubscriberConfiguration config)
         {
             _log = log;
             _config = config;
@@ -29,12 +29,12 @@ namespace Pat.Subscriber.BatchProcessing
                 {
                     if (ex is ServiceBusCommunicationException)
                     {
-                        _log.Warn("MessagingCommunicationException was thrown, queue handler will retry to get messages from service bus soon.", ex);
+                        _log.LogWarning(ex, "MessagingCommunicationException was thrown, queue handler will retry to get messages from service bus soon.");
                         Thread.Sleep(2000);
                     }
                     else
                     {
-                        _log.Fatal($"Unhandled non transient exception on queue {_config.SubscriberName}. Terminating queuehandler", ex);
+                        _log.LogError(ex, $"Unhandled non transient exception on queue {_config.SubscriberName}. Terminating queuehandler");
                         context.TokenSource.Cancel();
                     }
                     return true;
@@ -42,12 +42,12 @@ namespace Pat.Subscriber.BatchProcessing
             }
             catch (ServiceBusCommunicationException)
             {
-                _log.Warn("MessagingCommunicationException was thrown, subscriber will retry to get messages from service bus soon.");
+                _log.LogWarning("MessagingCommunicationException was thrown, subscriber will retry to get messages from service bus soon.");
                 Thread.Sleep(2000);
             }
             catch (Exception exception)
             {
-                _log.Fatal($"Unhandled non transient exception on queue {_config.SubscriberName}. Terminating queuehandler", exception);
+                _log.LogError(exception, $"Unhandled non transient exception on queue {_config.SubscriberName}. Terminating queuehandler");
                 context.TokenSource.Cancel();
             }
         }

--- a/Pat.Subscriber/BatchProcessor.cs
+++ b/Pat.Subscriber/BatchProcessor.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using log4net;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber.BatchProcessing;
 
 namespace Pat.Subscriber
@@ -10,11 +10,11 @@ namespace Pat.Subscriber
     {
         private readonly BatchProcessingBehaviourPipeline _batchProcessingBehaviourPipeline;
         private readonly BatchFactory _batchFactory;
-        private readonly ILog _log;
+        private readonly ILogger _log;
 
         public BatchProcessor(BatchProcessingBehaviourPipeline batchProcessingBehaviourPipeline,
             BatchFactory batchFactory,
-            ILog log)
+            ILogger log)
         {
             _batchProcessingBehaviourPipeline = batchProcessingBehaviourPipeline;
             _batchFactory = batchFactory;
@@ -29,7 +29,7 @@ namespace Pat.Subscriber
                 await batch.ReceiveMessages(messageReceiver).ConfigureAwait(false);
                 if (batch.HasMessages)
                 {
-                    _log.Debug($"Message collection processing {batch.MessageCount} messages");
+                    _log.LogDebug($"Message collection processing {batch.MessageCount} messages");
                     await batch.ProcessMessages().ConfigureAwait(false);
                 }
             }, tokenSource);

--- a/Pat.Subscriber/CicuitBreaker/CircuitBreakerBatchProcessingBehaviour.cs
+++ b/Pat.Subscriber/CicuitBreaker/CircuitBreakerBatchProcessingBehaviour.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber.BatchProcessing;
 
 namespace Pat.Subscriber.CicuitBreaker
@@ -33,7 +33,7 @@ namespace Pat.Subscriber.CicuitBreaker
             Open
         }
         public CircuitState State { get; private set; }
-        private readonly ILog _log;
+        private readonly ILogger _log;
         private readonly SubscriberConfiguration _config;
         private readonly int _circuitTestIntervalInSeconds;
         public Func<Exception, bool> ShouldCircuitBreak { get; set; }
@@ -41,7 +41,7 @@ namespace Pat.Subscriber.CicuitBreaker
         private event CircuitResetHandler CircuitReset;
         private event CircuitTestHandler CircuitTest;
 
-        public CircuitBreakerBatchProcessingBehaviour(ILog log, SubscriberConfiguration config, CircuitBreakerOptions circuitBreakerOptions)
+        public CircuitBreakerBatchProcessingBehaviour(ILogger log, SubscriberConfiguration config, CircuitBreakerOptions circuitBreakerOptions)
         {
             _log = log;
             _config = config;
@@ -91,14 +91,14 @@ namespace Pat.Subscriber.CicuitBreaker
 
         public void BreakCircuit()
         {
-            _log.Warn($"Subscriber circuit breaker: circuit opened for subscriber '{_config.SubscriberName}'");
+            _log.LogWarning($"Subscriber circuit breaker: circuit opened for subscriber '{_config.SubscriberName}'");
             State = CircuitState.Open;
             OnCircuitBroken(EventArgs.Empty);
         }
 
         public void CloseCircuit()
         {
-            _log.Info($"Subscriber circuit breaker: circuit closed for subscriber '{_config.SubscriberName}'");
+            _log.LogInformation($"Subscriber circuit breaker: circuit closed for subscriber '{_config.SubscriberName}'");
             State = CircuitState.Closed;
             OnCircuitReset(EventArgs.Empty);
         }
@@ -106,7 +106,7 @@ namespace Pat.Subscriber.CicuitBreaker
         public Task TestCircuit(Func<BatchContext, Task> next, BatchContext context)
         {
             OnCircuitTest(EventArgs.Empty);
-            _log.Info($"Subscriber circuit breaker: testing circuit for subscriber '{_config.SubscriberName}'");
+            _log.LogInformation($"Subscriber circuit breaker: testing circuit for subscriber '{_config.SubscriberName}'");
             State = CircuitState.HalfOpen;
             return next(context);
         }

--- a/Pat.Subscriber/MessageReceiverFactory.cs
+++ b/Pat.Subscriber/MessageReceiverFactory.cs
@@ -1,13 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
-using log4net;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Pat.Subscriber
 {
     public abstract class MessageReceiverFactory
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
         private readonly SubscriberConfiguration _config;
 
         protected abstract IMessageReceiver CreateMessageReceiver(
@@ -15,7 +15,7 @@ namespace Pat.Subscriber
             string topicName,
             string subscriberName);
 
-        protected MessageReceiverFactory(ILog log, SubscriberConfiguration config)
+        protected MessageReceiverFactory(ILogger log, SubscriberConfiguration config)
         {
             _log = log;
             _config = config;
@@ -42,13 +42,13 @@ namespace Pat.Subscriber
             {
                 if (!string.IsNullOrEmpty(connectionString))
                 {
-                    _log.Info($"Adding on subscription client {clientIndex} to list of source subscriptions");
+                    _log.LogInformation($"Adding on subscription client {clientIndex} to list of source subscriptions");
                     messageReceivers.Add(CreateMessageReceiver(connectionString,
                         _config.EffectiveTopicName, _config.SubscriberName));
                 }
                 else
                 {
-                    _log.Info($"Skipping subscription client {clientIndex}, connection string is null or empty");
+                    _log.LogInformation($"Skipping subscription client {clientIndex}, connection string is null or empty");
                 }
                 clientIndex++;
             }

--- a/Pat.Subscriber/MultipleBatchProcessor.cs
+++ b/Pat.Subscriber/MultipleBatchProcessor.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using log4net;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Pat.Subscriber
 {
@@ -12,9 +12,9 @@ namespace Pat.Subscriber
     {
         private readonly BatchProcessor _batchProcessor;
         private readonly string _subscriberName;
-        private readonly ILog _log;
+        private readonly ILogger _log;
 
-        public MultipleBatchProcessor(BatchProcessor batchProcessor, ILog log, string subscriberName)
+        public MultipleBatchProcessor(BatchProcessor batchProcessor, ILogger log, string subscriberName)
         {
             _batchProcessor = batchProcessor;
             _log = log;
@@ -36,13 +36,13 @@ namespace Pat.Subscriber
                             }
                             catch (Exception exception)
                             {
-                                _log.Fatal(
-                                    $"Unhandled non transient exception on queue {_subscriberName}. Terminating queuehandler from ProcessBatchChain.",
-                                    exception);
+                                _log.LogError(
+                                    exception,
+                                    $"Unhandled non transient exception on queue {_subscriberName}. Terminating queuehandler from ProcessBatchChain.");
                                 tokenSource.Cancel();
                             }
                         }
-                        _log.Info("Shutting down...");
+                        _log.LogInformation("Shutting down...");
                     }, tokenSource.Token));
 
             return Task.WhenAll(tasks.ToArray());

--- a/Pat.Subscriber/Pat.Subscriber.csproj
+++ b/Pat.Subscriber/Pat.Subscriber.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Purplebricks</Company>
-    <Version>1.0.0</Version>
+    <Version>0.0.0</Version>
     <Summary>Purplebricks message subscriber infrastructure.</Summary>
     <Description>Purplebricks message subscriber infrastructure</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,13 +13,8 @@
     <RepositoryUrl>https://github.com/purplebricks/Pat.Subscriber</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NET451'">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'NETSTANDARD2.0'">
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/Pat.Subscriber/Subscriber.cs
+++ b/Pat.Subscriber/Subscriber.cs
@@ -1,24 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using log4net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
 using Microsoft.Azure.ServiceBus.Core;
 using Pat.Subscriber.MessageMapping;
 using Pat.Subscriber.SubscriberRules;
+using Microsoft.Extensions.Logging;
 
 namespace Pat.Subscriber
 {
     public class Subscriber
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
         private readonly SubscriberConfiguration _config;
         private readonly MultipleBatchProcessor _multipleBatchProcessor;
         private readonly MessageReceiverFactory _messageReceiverFactory;
 
-        public Subscriber(ILog log,  SubscriberConfiguration config, MultipleBatchProcessor multipleBatchProcessor, MessageReceiverFactory messageReceiverFactory)
+        public Subscriber(ILogger log,  SubscriberConfiguration config, MultipleBatchProcessor multipleBatchProcessor, MessageReceiverFactory messageReceiverFactory)
         {
             _log = log;
             _config = config;
@@ -57,7 +57,7 @@ namespace Pat.Subscriber
             string handlerName = null;
             if (messagesTypes.Length == 0)
             {
-                _log.Warn("Subscriber does not handle any message types");
+                _log.LogWarning("Subscriber does not handle any message types");
             }
             else
             {
@@ -87,7 +87,7 @@ namespace Pat.Subscriber
 
            var receivers = _messageReceiverFactory.CreateReceivers();
 
-            _log.Info("Listening for messages...");
+            _log.LogInformation("Listening for messages...");
 
             await _multipleBatchProcessor.ProcessMessages(receivers, tokenSource).ConfigureAwait(false);
         }

--- a/Pat.Subscriber/SubscriberRules/RuleApplier.cs
+++ b/Pat.Subscriber/SubscriberRules/RuleApplier.cs
@@ -1,15 +1,15 @@
 using System.Threading.Tasks;
-using log4net;
 using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
 
 namespace Pat.Subscriber.SubscriberRules
 { 
     public class RuleApplier: IRuleApplier
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
         private readonly SubscriptionClient _client;
 
-        public RuleApplier(ILog log, SubscriptionClient client)
+        public RuleApplier(ILogger log, SubscriptionClient client)
         {
             _log = log;
             _client = client;
@@ -17,14 +17,14 @@ namespace Pat.Subscriber.SubscriberRules
 
         public async Task RemoveRule(RuleDescription rule)
         {
-            _log.Info($"Deleting rule {rule.Name} for subscriber {_client.SubscriptionName}, as it has been superceded by a newer version");
+            _log.LogInformation($"Deleting rule {rule.Name} for subscriber {_client.SubscriptionName}, as it has been superceded by a newer version");
             await _client.RemoveRuleAsync(rule.Name).ConfigureAwait(false);
         }
 
         public async Task AddRule(RuleDescription rule)
         {
             var newRule = (SqlFilter)rule.Filter;
-            _log.Info($"Creating rule {rule.Name} for subscriber {_client.SubscriptionName}");
+            _log.LogInformation($"Creating rule {rule.Name} for subscriber {_client.SubscriptionName}");
             await _client.AddRuleAsync(rule).ConfigureAwait(false);
         }
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.{build}
+version: 2.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:


### PR DESCRIPTION
Replace log4net with .NET Core Logging, removing support for net451 in the process.  Use .AddDefaultPatLogger (.NET Core IoC) or .WithDefaultPatLogger (StructureMap IoC)