### PR TITLE
Update Microsoft.Azure.ServiceBus to 3.1.1 to Bring in Big Fix

### DIFF
--- a/Pat.Subscriber.RateLimiterPolicy/Pat.Subscriber.RateLimiterPolicy.csproj
+++ b/Pat.Subscriber.RateLimiterPolicy/Pat.Subscriber.RateLimiterPolicy.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Nito.Collections.Deque" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pat.Subscriber\Pat.Subscriber.csproj" />

--- a/Pat.Subscriber.Telemetry.StatsD/Pat.Subscriber.Telemetry.StatsD.csproj
+++ b/Pat.Subscriber.Telemetry.StatsD/Pat.Subscriber.Telemetry.StatsD.csproj
@@ -16,9 +16,6 @@
     <PackageReference Include="StatsdClient" Version="3.0.86" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Pat.Subscriber\Pat.Subscriber.csproj" />
   </ItemGroup>
 </Project>

--- a/Pat.Subscriber/Pat.Subscriber.csproj
+++ b/Pat.Subscriber/Pat.Subscriber.csproj
@@ -15,6 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This update is to bring in the fix for https://github.com/Azure/azure-service-bus-dotnet/issues/359 which we are impacted by. Logs show:

```
Pat : ERROR, Unhandled non transient exception on queue <Redacted>. Terminating queuehandler, Microsoft.Azure.ServiceBus.ServiceBusException: Unauthorized access. 'Listen' claim(s) are required to perform this operation. Resource: '<Redacted>'.
   at Microsoft.Azure.ServiceBus.Core.MessageReceiver.OnReceiveAsync(Int32 maxMessageCount, TimeSpan serverWaitTime)
   at Microsoft.Azure.ServiceBus.Core.MessageReceiver.<>c__DisplayClass62_0.<<ReceiveAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.ServiceBus.RetryPolicy.RunOperation(Func`1 operation, TimeSpan operationTimeout)
   at Microsoft.Azure.ServiceBus.RetryPolicy.RunOperation(Func`1 operation, TimeSpan operationTimeout)
   at Microsoft.Azure.ServiceBus.Core.MessageReceiver.ReceiveAsync(Int32 maxMessageCount, TimeSpan operationTimeout)
   at Pat.Subscriber.SubscriptionHelper.GetMessages(IMessageReceiver messageReceiver, Int32 batchSize, Int32 receiveTimeoutSeconds)
   at Pat.Subscriber.Batch.ReceiveMessages(IMessageReceiver messageReceiver)
   at Pat.Subscriber.BatchProcessor.<>c__DisplayClass4_0.<<ProcessBatch>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Pat.Subscriber.BatchProcessing.DefaultBatchProcessingBehaviour.Invoke(Func`2 next, BatchContext context)```