### PR TITLE
Updated to latest ASB packages and explicitly Abandon message on fail…

### DIFF
--- a/Pat.Subscriber.RateLimiterPolicy/Pat.Subscriber.RateLimiterPolicy.csproj
+++ b/Pat.Subscriber.RateLimiterPolicy/Pat.Subscriber.RateLimiterPolicy.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Nito.Collections.Deque" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pat.Subscriber\Pat.Subscriber.csproj" />

--- a/Pat.Subscriber/MessageProcessing/DefaultMessageProcessingBehaviour.cs
+++ b/Pat.Subscriber/MessageProcessing/DefaultMessageProcessingBehaviour.cs
@@ -40,13 +40,14 @@ namespace Pat.Subscriber.MessageProcessing
             catch (Exception ex)
             {
                 await HandleException(ex, messageContext).ConfigureAwait(false);
+                messageContext.MessageReceiver.AbandonAsync(message.SystemProperties.LockToken).ConfigureAwait(false);               
             }
         }
 
-        protected virtual Task HandleException(Exception ex, MessageContext messageContext)
+        protected virtual async Task HandleException(Exception ex, MessageContext messageContext)
         {
             _log.LogInformation(ex, $"Message {messageContext.Message.MessageId} failed");
-            return Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         protected string GetMessageType(Message message)

--- a/Pat.Subscriber/Pat.Subscriber.csproj
+++ b/Pat.Subscriber/Pat.Subscriber.csproj
@@ -15,6 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.2.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…ure.

From running locally with dotMemory there appeared to be a memory leak before, this seems to be fixed or atleast dramatically improved from running locally. Whereas before running a subscriber that always threw an exception after a few minutes would freeze/lock, this has run for considerably longer without freezing. #30