### PR TITLE
Log message processing exceptions at Error level not Information

### DIFF
--- a/Pat.Subscriber/MessageProcessing/DefaultMessageProcessingBehaviour.cs
+++ b/Pat.Subscriber/MessageProcessing/DefaultMessageProcessingBehaviour.cs
@@ -43,9 +43,9 @@ namespace Pat.Subscriber.MessageProcessing
             }
         }
 
-        protected virtual Task HandleException(Exception ex, MessageContext messageContext)
+        protected virtual Task HandleException(Exception exception, MessageContext messageContext)
         {
-            _log.LogInformation(ex, $"Message {messageContext.Message.MessageId} failed");
+            _log.LogError(exception, $"Message {messageContext.Message.MessageId} failed: {exception.Message}");
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Also include inner exception message to help diagnose issues more quickly when examining logs.

(e.g. Application Insights currently only shows the outermost exception message)