### PR TITLE
Add Support for Mixed Case Synthetic Header

### DIFF
--- a/Pat.Subscriber.UnitTests/RuleBuilderTests.cs
+++ b/Pat.Subscriber.UnitTests/RuleBuilderTests.cs
@@ -80,11 +80,11 @@ namespace Pat.Subscriber.UnitTests
         {
             var messagesTypes = CreateEnoughMessageTypesToSpanMultipleRules();
             var rules = _ruleBuilder.GenerateSubscriptionRules(messagesTypes, _handlerName);
-
+            
             foreach (var rule in rules)
             {
                 var filter = ((SqlFilter)rule.Filter).SqlExpression;
-                Assert.Contains("(NOT EXISTS(Synthetic) OR Synthetic <> 'true' ", filter);
+                Assert.Contains("(NOT EXISTS(Synthetic) OR (Synthetic <> 'true' AND Synthetic <> 'True' AND Synthetic <> 'TRUE') ", filter);
             }
         }
 

--- a/Pat.Subscriber/SubscriberRules/RuleBuilder.cs
+++ b/Pat.Subscriber/SubscriberRules/RuleBuilder.cs
@@ -29,10 +29,10 @@ namespace Pat.Subscriber.SubscriberRules
 
             if (string.IsNullOrEmpty(syntheticFilter))
             {
-                return $"(NOT EXISTS(Synthetic) OR Synthetic <> 'true')";
+                return $"(NOT EXISTS(Synthetic) OR (Synthetic <> 'true' AND Synthetic <> 'True' AND Synthetic <> 'TRUE'))";
             }
 
-            return $"(NOT EXISTS(Synthetic) OR Synthetic <> 'true' OR {syntheticFilter})";
+            return $"(NOT EXISTS(Synthetic) OR (Synthetic <> 'true' AND Synthetic <> 'True' AND Synthetic <> 'TRUE') OR {syntheticFilter})";
         }
 
         public List<string> GenerateMessageTypeFilterClause(IEnumerable<string> messagesTypeFilters, int initialFilterLength)


### PR DESCRIPTION
The Synthetic header is oftern passed as 'True' as this is the default casing for bool.ToString, this side steps the issue.