### PR TITLE
Make RuleBuilder allow for tests to eavesdrop on commands

### DIFF
--- a/Pat.Subscriber.IntegrationTests/SubscriberFixture.cs
+++ b/Pat.Subscriber.IntegrationTests/SubscriberFixture.cs
@@ -14,7 +14,7 @@ namespace Pat.Subscriber.IntegrationTests
         public bool IntegrationTest { get; }
         public bool AppVeyorCIBuild { get; }
 
-        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private readonly Task _subscriberTask;
 
         public SubscriberFixture()
@@ -63,7 +63,7 @@ namespace Pat.Subscriber.IntegrationTests
             }
 
             var subscriber = ServiceProvider.GetService<Subscriber>();
-            _cancellationTokenSource = new CancellationTokenSource();
+            
             if (subscriber.Initialise(new[] {typeof(SubscriberTests).Assembly}).GetAwaiter().GetResult())
             {
                 _subscriberTask = Task.Run(() => subscriber.ListenForMessages(_cancellationTokenSource));
@@ -73,7 +73,7 @@ namespace Pat.Subscriber.IntegrationTests
         public void Dispose()
         {
             _cancellationTokenSource.Cancel();
-            _subscriberTask.Wait();
+            _subscriberTask?.Wait();
         }
     }
 }

--- a/Pat.Subscriber/SubscriberConfiguration.cs
+++ b/Pat.Subscriber/SubscriberConfiguration.cs
@@ -63,5 +63,10 @@ namespace Pat.Subscriber
         /// Amount of time in seconds receive should wait before timing out if no messages are available before returning 
         /// </summary>
         public int ReceiveTimeoutSeconds { get; set; }
+
+        /// <summary>
+        /// Only to be used by service tests to allow eavesdropping on outgoing commands.
+        /// </summary>
+        public bool OmitSpecificSubscriberFilter { get; set; }
     }
 }

--- a/Pat.Subscriber/SubscriptionBuilder.cs
+++ b/Pat.Subscriber/SubscriptionBuilder.cs
@@ -61,7 +61,7 @@ namespace Pat.Subscriber
             var ruleApplier = new RuleApplier(_ruleApplierLog, client);
             var ruleBuilder = new RuleBuilder(ruleApplier, _subscriptionRuleVersionResolver, _config.SubscriberName);
 
-            var rulesForCurrentSoftwareVersion = ruleBuilder.GenerateSubscriptionRules(messagesTypes, handlerFullName).ToArray();
+            var rulesForCurrentSoftwareVersion = ruleBuilder.GenerateSubscriptionRules(messagesTypes, handlerFullName, _config.OmitSpecificSubscriberFilter).ToArray();
             var rulesCurrentlyDefinedInServiceBus = await client.GetRulesAsync().ConfigureAwait(false);
 
             _log.LogInformation($"Validating subscription '{_config.SubscriberName}' rules on topic '{topicName}'...");


### PR DESCRIPTION
As discussed, this is a configurable option to remove the "SpecificSubscriber" clause from the rules, so in the rare case of an external command, we can listen for it in our service tests