### PR TITLE
Add a more descriptive MessagingEntityNotFoundException message

### DIFF
--- a/Pat.Subscriber/SubscriptionBuilder.cs
+++ b/Pat.Subscriber/SubscriptionBuilder.cs
@@ -42,7 +42,7 @@ namespace Pat.Subscriber
                     }
                     catch (MessagingEntityNotFoundException)
                     {
-                        _log.LogCritical($"Unable to find servicebus topic '{_config.EffectiveTopicName}' subscriber will terminate.");
+                        _log.LogCritical($"Unable to find Service Bus subscription '{_config.SubscriberName}' for topic '{_config.EffectiveTopicName}'. Subscriber will terminate.");
                         return false;
                     }
                 }


### PR DESCRIPTION
A `MessagingEntityNotFoundException` can be thrown if the subscription or the topic cannot be found. 

Making the exception message reflect this might save someone using the library some time.